### PR TITLE
GTMへ日付データも渡す

### DIFF
--- a/single-event.php
+++ b/single-event.php
@@ -7,7 +7,7 @@ get_header();
   <div id="content" class="<?php echo $post_type; ?> single contact">
 <!-- dataLayer -->
   <script>
-    dataLayer.push({'eventname_form': 'eventname_form_<?php echo get_post($post->post_parent)->post_title; ?>'});
+    dataLayer.push({'eventname_form': 'eventname_form_<?php echo get_post($post->post_parent)->post_title; ?>_<?php echo get_post_meta($post->post_parent, 'cf_overview_cf_date', true); ?>'});
   </script>
 <!-- dataLayer -->
   <article class="article_main">


### PR DESCRIPTION
### overView
GTMへ渡すデータへ日本語の日付情報も含める。

### why
全く同じ記事名で開催日付が違うという運用が直前で明らかになったため、HubSpot & GAでの同定を可能にするため。