### PR TITLE
子記事の一覧掲出を封じる

### DIFF
--- a/index.php
+++ b/index.php
@@ -204,6 +204,7 @@
           <?php
           $args = array(
             'post_type' => 'event',
+            'post_parent' => 0,
             'posts_per_page' => 5,
             'post_status' => 'publish',
             'order' => 'DESC',


### PR DESCRIPTION
### overview
イベントでの申し込みページが子記事であるため、indexの一覧でも掲出を封じる必要が生じた。