### PR TITLE
イベント終了日時設定　修正

### DIFF
--- a/single-event.php
+++ b/single-event.php
@@ -55,6 +55,7 @@ get_header();
   date_default_timezone_set('Asia/Tokyo'); $date_now = date('YmdHi');
   if($overview['cf_date_end'])$date_end = $overview['cf_date_end'];
   if( intval(get_field('cf_event_target')) === 1 || $date_now >= $date_end ):
+  date_default_timezone_set('UTC');
 ?>
 
   <script>


### PR DESCRIPTION
イベントページのイベント終了日時設定が正しく動作していない
https://trello.com/c/SXtidtF6
上記チケットの対応をしました。

原因と行なった内容
https://tec-aid.com/archives/1716/
https://github.com/yhira/cocoon/issues/18